### PR TITLE
Rework of the Tip Selection algorithm, to better match the IOTA whitepaper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>uk.co.froot.maven.enforcer</groupId>
             <artifactId>digest-enforcer-rules</artifactId>

--- a/src/main/java/com/iota/iri/conf/Configuration.java
+++ b/src/main/java/com/iota/iri/conf/Configuration.java
@@ -103,7 +103,8 @@ public class Configuration {
         NUMBER_OF_KEYS_IN_A_MILESTONE,
         TRANSACTION_PACKET_SIZE,
         REQUEST_HASH_SIZE,
-        SNAPSHOT_TIME
+        SNAPSHOT_TIME,
+        TIPSELECTION_ALPHA
     }
 
 
@@ -168,6 +169,8 @@ public class Configuration {
         conf.put(DefaultConfSettings.TRANSACTION_PACKET_SIZE.name(), PACKET_SIZE);
         conf.put(DefaultConfSettings.REQUEST_HASH_SIZE.name(), REQ_HASH_SIZE);
         conf.put(DefaultConfSettings.SNAPSHOT_TIME.name(), GLOBAL_SNAPSHOT_TIME);
+        conf.put(DefaultConfSettings.TIPSELECTION_ALPHA.name(), "0.1");
+
     }
 
     public boolean init() throws IOException {

--- a/src/main/java/com/iota/iri/model/Hash.java
+++ b/src/main/java/com/iota/iri/model/Hash.java
@@ -11,7 +11,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
 
-public final class Hash implements Serializable, Indexable {
+public final class Hash implements Serializable, Indexable, HashId {
 
     public static final int SIZE_IN_TRITS = 243;
     public static final int SIZE_IN_BYTES = 49;

--- a/src/main/java/com/iota/iri/model/HashId.java
+++ b/src/main/java/com/iota/iri/model/HashId.java
@@ -1,0 +1,13 @@
+package com.iota.iri.model;
+
+/**
+ * Represents an ID of a transaction, address or bundle
+ */
+public interface HashId {
+
+    /**
+     *
+     * @return the bytes of the Hash Id
+     */
+    byte[] bytes();
+}

--- a/src/main/java/com/iota/iri/model/HashPrefix.java
+++ b/src/main/java/com/iota/iri/model/HashPrefix.java
@@ -1,0 +1,61 @@
+package com.iota.iri.model;
+
+import com.iota.iri.hash.Curl;
+import com.iota.iri.utils.Converter;
+
+import java.util.Arrays;
+
+public final class HashPrefix implements HashId {
+    public static final int PREFIX_LENGTH = 44;
+    private final byte[] bytes;
+
+    public static HashPrefix createPrefix(HashId hashId) {
+        if (hashId == null) {
+            return null;
+        }
+        if (hashId instanceof HashPrefix) {
+            return (HashPrefix) hashId;
+        }
+
+        byte[] bytes = hashId.bytes();
+        bytes = Arrays.copyOf(bytes, PREFIX_LENGTH);
+        return new HashPrefix(bytes);
+    }
+
+    private HashPrefix(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public byte[] bytes() {
+        return bytes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HashPrefix that = (HashPrefix) o;
+        return Arrays.equals(bytes, that.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return trytes(bytes);
+    }
+
+    private static String trytes(byte[] bytes) {
+        int[] dest = new int[Curl.HASH_LENGTH];
+        Converter.getTrits(bytes, dest);
+        return Converter.trytes(dest);
+    }
+}

--- a/src/main/java/com/iota/iri/service/tipselection/EntryPointSelector.java
+++ b/src/main/java/com/iota/iri/service/tipselection/EntryPointSelector.java
@@ -1,0 +1,27 @@
+package com.iota.iri.service.tipselection;
+
+import com.iota.iri.model.Hash;
+
+/**
+ * Selects an entryPoint for tip selection.
+ * <p>
+ * this point is used as the starting point where
+ * the particle starts the random walk.
+ * </p>
+ */
+
+public interface EntryPointSelector {
+
+    /**
+     *get an entryPoint for tip selection
+     *
+     *Uses depth to determine the entry point for
+     *the random walk.
+     *
+     * @param depth Depth, in milestones. a notion of how deep to search for a good starting point.
+     * @return  Entry point for walk method
+     * @throws Exception If DB fails to retrieve transactions
+     */
+    Hash getEntryPoint(int depth)throws Exception;
+
+}

--- a/src/main/java/com/iota/iri/service/tipselection/RatingCalculator.java
+++ b/src/main/java/com/iota/iri/service/tipselection/RatingCalculator.java
@@ -1,0 +1,26 @@
+package com.iota.iri.service.tipselection;
+
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashId;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+
+/**
+ * Calculates the rating for a sub graph
+ */
+@FunctionalInterface
+public interface RatingCalculator {
+
+    /**
+     * Rating calculator
+     * <p>
+     * Calculates the rating of all the transactions that reference
+     * a given entry point.
+     * </p>
+     *
+     * @param entryPoint  Transaction hash of a selected entry point.
+     * @return  Map
+     * @throws Exception If DB fails to retrieve transactions
+     */
+
+    UnIterableMap<HashId, Integer> calculate(Hash entryPoint) throws Exception;
+}

--- a/src/main/java/com/iota/iri/service/tipselection/TailFinder.java
+++ b/src/main/java/com/iota/iri/service/tipselection/TailFinder.java
@@ -1,0 +1,27 @@
+package com.iota.iri.service.tipselection;
+
+import com.iota.iri.model.Hash;
+
+import java.util.Optional;
+
+/**
+ * Finds the tail of a bundle
+ */
+
+@FunctionalInterface
+public interface TailFinder {
+    /**
+     *Method for finding tails of bundles
+     *
+     * <p>
+     *  This method is used to find a tail (current_index=0) of a bundle,
+     *  given any transaction hash in the bundle.
+     * </p>
+     *
+     * @param hash The transaction hash of any transaction in the bundle.
+     * @return  Hash of the tail transaction.
+     * @throws Exception If DB fails to retrieve transactions
+     */
+    Optional<Hash> findTail(Hash hash) throws Exception;
+
+}

--- a/src/main/java/com/iota/iri/service/tipselection/TipSelector.java
+++ b/src/main/java/com/iota/iri/service/tipselection/TipSelector.java
@@ -1,0 +1,30 @@
+package com.iota.iri.service.tipselection;
+
+import com.iota.iri.model.Hash;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Selects tips to be approved
+ */
+
+
+public interface TipSelector {
+
+    /**
+     * Method for finding tips
+     *
+     * <p>
+     *  This method is used to find tips for approval given a depth,
+     *  if reference is present then tips will also reference this transaction.
+     * </p>
+     *
+     * @param depth  The depth that the transactions will be found from.
+     * @param reference  An optional transaction hash to be referenced by tips.
+     * @return  Transactions to approve
+     * @throws Exception If DB fails to retrieve transactions
+     */
+    List<Hash> getTransactionsToApprove(int depth, Optional<Hash> reference) throws Exception;
+
+    int getMaxDepth();
+}

--- a/src/main/java/com/iota/iri/service/tipselection/WalkValidator.java
+++ b/src/main/java/com/iota/iri/service/tipselection/WalkValidator.java
@@ -1,0 +1,23 @@
+package com.iota.iri.service.tipselection;
+
+import com.iota.iri.model.Hash;
+
+/**
+ * Validates consistency of tails.
+ */
+@FunctionalInterface
+public interface WalkValidator {
+
+    /**
+     * Validation
+     * <p>
+     * Checks if a given transaction is a valid tail.
+     * </p>
+     *
+     * @param transactionHash  Transaction hash to validate consistency of.
+     * @return  True iff tail is valid.
+     * @throws Exception If Validation fails to execute
+     */
+    boolean isValid(Hash transactionHash) throws Exception;
+
+}

--- a/src/main/java/com/iota/iri/service/tipselection/Walker.java
+++ b/src/main/java/com/iota/iri/service/tipselection/Walker.java
@@ -1,0 +1,29 @@
+package com.iota.iri.service.tipselection;
+
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashId;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+
+/**
+ * Walks the tangle from an entry point towards tips
+ *
+ */
+
+public interface Walker {
+
+    /**
+     * Walk algorithm
+     * <p>
+     * Starts from given entry point to select valid transactions to be used
+     * as tips. It will output a valid transaction as a tip.
+     * </p>
+     *
+     * @param entryPoint  Transaction hash to start walk from.
+     * @param ratings  Map of ratings for each transaction that references entryPoint.
+     * @param walkValidator Used to validate consistency of tails.
+     * @return  Transaction hash of tip.
+     * @throws Exception If DB fails to retrieve transactions
+     */
+    Hash walk(Hash entryPoint, UnIterableMap<HashId, Integer> ratings, WalkValidator walkValidator) throws Exception;
+
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/CumulativeWeightCalculator.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/CumulativeWeightCalculator.java
@@ -1,0 +1,161 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.controllers.ApproveeViewModel;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashId;
+import com.iota.iri.model.HashPrefix;
+import com.iota.iri.service.tipselection.RatingCalculator;
+import com.iota.iri.utils.collections.impl.TransformingBoundedHashSet;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.collections.impl.TransformingMap;
+import com.iota.iri.utils.collections.interfaces.BoundedSet;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.SetUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * Implementation of <tt>RatingCalculator</tt> that gives the cumulative for each transaction referencing entryPoint.
+ * Used to create a weighted random walks.
+ *
+ * @see <a href="cumulative.md">https://github.com/alongalky/iota-docs/blob/master/cumulative.md</a>
+ */
+public class CumulativeWeightCalculator implements RatingCalculator{
+
+    private static final Logger log = LoggerFactory.getLogger(CumulativeWeightCalculator.class);
+    public static final int MAX_ANCESTORS_SIZE = 5000;
+
+    public final Tangle tangle;
+
+    public CumulativeWeightCalculator(Tangle tangle) {
+        this.tangle = tangle;
+    }
+
+    @Override
+    public UnIterableMap<HashId, Integer> calculate(Hash entryPoint) throws Exception {
+        log.debug("Start calculating cw starting with tx hash {}", entryPoint);
+
+        LinkedHashSet<Hash> txHashesToRate = sortTransactionsInTopologicalOrder(entryPoint);
+        return calculateCwInOrder(txHashesToRate);
+    }
+
+    //Uses DFS algorithm to sort
+    private LinkedHashSet<Hash> sortTransactionsInTopologicalOrder(Hash startTx) throws Exception {
+        LinkedHashSet<Hash> sortedTxs = new LinkedHashSet<>();
+        Deque<Hash> stack = new ArrayDeque<>();
+        Map<Hash, Collection<Hash>> txToDirectApprovers = new HashMap<>();
+
+        stack.push(startTx);
+        while (CollectionUtils.isNotEmpty(stack)) {
+            Hash txHash = stack.peek();
+            if (!sortedTxs.contains(txHash)) {
+                Collection<Hash> appHashes = getTxDirectApproversHashes(txHash, txToDirectApprovers);
+                if (CollectionUtils.isNotEmpty(appHashes)) {
+                    Hash txApp = getAndRemoveApprover(appHashes);
+                    stack.push(txApp);
+                    continue;
+                }
+            }
+            else {
+                stack.pop();
+                continue;
+            }
+            sortedTxs.add(txHash);
+        }
+
+        return sortedTxs;
+    }
+
+    private Hash getAndRemoveApprover(Collection<Hash> appHashes) {
+        Iterator<Hash> hashIterator = appHashes.iterator();
+        Hash txApp = hashIterator.next();
+        hashIterator.remove();
+        return txApp;
+    }
+
+    private Collection<Hash> getTxDirectApproversHashes(Hash txHash, Map<Hash, Collection<Hash>> txToDirectApprovers)
+            throws Exception {
+        Collection<Hash> txApprovers = txToDirectApprovers.get(txHash);
+        if (txApprovers == null) {
+            ApproveeViewModel approvers = ApproveeViewModel.load(tangle, txHash);
+            Collection<Hash> appHashes = CollectionUtils.emptyIfNull(approvers.getHashes());
+            txApprovers = new HashSet<>(appHashes.size());
+            for (Hash appHash : appHashes) {
+                //if not genesis (the tx that confirms itself)
+                if (ObjectUtils.notEqual(Hash.NULL_HASH, appHash)) {
+                    txApprovers.add(appHash);
+                }
+            }
+            txToDirectApprovers.put(txHash, txApprovers);
+        }
+        return txApprovers;
+    }
+
+    //must specify using LinkedHashSet since Java has no interface that guarantees uniqueness and insertion order
+    private UnIterableMap<HashId, Integer> calculateCwInOrder(LinkedHashSet<Hash> txsToRate) throws Exception {
+        UnIterableMap<HashId, Set<HashId>> txHashToApprovers = createTxHashToApproversPrefixMap();
+        UnIterableMap<HashId, Integer> txHashToCumulativeWeight = createTxHashToCumulativeWeightMap(txsToRate.size());
+
+        Iterator<Hash> txHashIterator = txsToRate.iterator();
+        while (txHashIterator.hasNext()) {
+            Hash txHash = txHashIterator.next();
+            txHashToCumulativeWeight = updateCw(txHashToApprovers, txHashToCumulativeWeight, txHash);
+            txHashToApprovers = updateApproversAndReleaseMemory(txHashToApprovers, txHash);
+            txHashIterator.remove();
+        }
+        return txHashToCumulativeWeight;
+    }
+
+
+    private UnIterableMap<HashId, Set<HashId>> updateApproversAndReleaseMemory(UnIterableMap<HashId,
+                    Set<HashId>> txHashToApprovers, Hash txHash) throws Exception {
+        Set<HashId> approvers = SetUtils.emptyIfNull(txHashToApprovers.get(txHash));
+
+        TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, txHash);
+        Hash trunkHash = transactionViewModel.getTrunkTransactionHash();
+        Hash branchHash = transactionViewModel.getBranchTransactionHash();
+
+        Set<HashId> trunkApprovers = createApprovers(txHashToApprovers, txHash, approvers, trunkHash);
+        txHashToApprovers.put(trunkHash, trunkApprovers);
+        Set<HashId> branchApprovers = createApprovers(txHashToApprovers, txHash, approvers, branchHash);
+        txHashToApprovers.put(branchHash, branchApprovers);
+
+        txHashToApprovers.remove(txHash);
+
+        return txHashToApprovers;
+    }
+
+    private Set<HashId> createApprovers(UnIterableMap<HashId, Set<HashId>> txHashToApprovers, HashId txHash,
+                                        Set<HashId> approvers, HashId trunkHash) {
+        approvers = createTransformingBoundedSet(approvers);
+        approvers.addAll(CollectionUtils.emptyIfNull(txHashToApprovers.get(trunkHash)));
+        approvers.add(txHash);
+        return approvers;
+    }
+
+    private static <T extends HashId> UnIterableMap<HashId, Integer> updateCw(
+            UnIterableMap<HashId, Set<T>> txHashToApprovers, UnIterableMap<HashId, Integer> txToCumulativeWeight,
+            Hash txHash) {
+        Set<T> approvers = txHashToApprovers.get(txHash);
+        int weight = CollectionUtils.emptyIfNull(approvers).size() + 1;
+        txToCumulativeWeight.put(txHash, weight);
+        return txToCumulativeWeight;
+    }
+
+    private static UnIterableMap<HashId, Set<HashId>> createTxHashToApproversPrefixMap() {
+       return new TransformingMap<>(HashPrefix::createPrefix, null);
+    }
+
+    private static UnIterableMap<HashId, Integer> createTxHashToCumulativeWeightMap(int size) {
+        return new TransformingMap<>(size, HashPrefix::createPrefix, null);
+    }
+
+    private static  BoundedSet<HashId> createTransformingBoundedSet(Collection<HashId> c) {
+        return new TransformingBoundedHashSet<>(c, MAX_ANCESTORS_SIZE, HashPrefix::createPrefix);
+    }
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/CumulativeWeightCalculator.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/CumulativeWeightCalculator.java
@@ -28,7 +28,7 @@ import java.util.*;
 public class CumulativeWeightCalculator implements RatingCalculator{
 
     private static final Logger log = LoggerFactory.getLogger(CumulativeWeightCalculator.class);
-    public static final int MAX_ANCESTORS_SIZE = 5000;
+    public static final int MAX_FUTURE_SET_SIZE = 5000;
 
     public final Tangle tangle;
 
@@ -132,10 +132,10 @@ public class CumulativeWeightCalculator implements RatingCalculator{
 
     private Set<HashId> createApprovers(UnIterableMap<HashId, Set<HashId>> txHashToApprovers, HashId txHash,
                                         Set<HashId> approvers, HashId trunkHash) {
-        approvers = createTransformingBoundedSet(approvers);
-        approvers.addAll(CollectionUtils.emptyIfNull(txHashToApprovers.get(trunkHash)));
-        approvers.add(txHash);
-        return approvers;
+        Set<HashId> approverSet = createTransformingBoundedSet(approvers);
+        approverSet.addAll(CollectionUtils.emptyIfNull(txHashToApprovers.get(trunkHash)));
+        approverSet.add(txHash);
+        return approverSet;
     }
 
     private static <T extends HashId> UnIterableMap<HashId, Integer> updateCw(
@@ -156,6 +156,6 @@ public class CumulativeWeightCalculator implements RatingCalculator{
     }
 
     private static  BoundedSet<HashId> createTransformingBoundedSet(Collection<HashId> c) {
-        return new TransformingBoundedHashSet<>(c, MAX_ANCESTORS_SIZE, HashPrefix::createPrefix);
+        return new TransformingBoundedHashSet<>(c, MAX_FUTURE_SET_SIZE, HashPrefix::createPrefix);
     }
 }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorImpl.java
@@ -1,0 +1,40 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.Milestone;
+import com.iota.iri.controllers.MilestoneViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.service.tipselection.EntryPointSelector;
+import com.iota.iri.storage.Tangle;
+
+/**
+ * Implementation of <tt>EntryPointSelector</tt> that given a depth N, returns a N-deep milestone.
+ * Meaning <CODE>milestone(latestSolid - depth)</CODE>
+ * Used to as a starting point for the random walk.
+ */
+public class EntryPointSelectorImpl implements EntryPointSelector {
+
+    private final Tangle tangle;
+    private final Milestone milestone;
+    private final boolean testnet;
+    private final int milestoneStartIndex;
+
+    public EntryPointSelectorImpl(Tangle tangle, Milestone milestone, boolean testnet, int milestoneStartIndex) {
+        this.tangle = tangle;
+        this.milestone = milestone;
+
+        this.testnet = testnet;
+        this.milestoneStartIndex = milestoneStartIndex;
+    }
+
+    @Override
+    public Hash getEntryPoint(int depth) throws Exception {
+        int milestoneIndex = Math.max(milestone.latestSolidSubtangleMilestoneIndex - depth - 1, 0);
+        MilestoneViewModel milestoneViewModel =
+                MilestoneViewModel.findClosestNextMilestone(tangle, milestoneIndex, testnet, milestoneStartIndex);
+        if (milestoneViewModel != null && milestoneViewModel.getHash() != null) {
+            return milestoneViewModel.getHash();
+        }
+
+        return milestone.latestSolidSubtangleMilestone;
+    }
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/RatingOne.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/RatingOne.java
@@ -1,0 +1,49 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.controllers.ApproveeViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashId;
+import com.iota.iri.service.tipselection.RatingCalculator;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.collections.impl.TransformingMap;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+
+import java.util.*;
+
+/**
+ * Implementation of <tt>RatingCalculator</tt> that gives a uniform rating of 1 to each transaction.
+ * Used to create uniform random walks.
+ */
+public class RatingOne implements RatingCalculator {
+
+    private final Tangle tangle;
+
+    public RatingOne(Tangle tangle) {
+        this.tangle = tangle;
+    }
+
+    public UnIterableMap<HashId, Integer> calculate(Hash entryPoint) throws Exception {
+        UnIterableMap<HashId, Integer> rating = new TransformingMap<>(null, null);
+
+        Queue<Hash> queue = new LinkedList<>();
+        queue.add(entryPoint);
+        rating.put(entryPoint, 1);
+
+        Hash hash;
+
+        //traverse all transactions that reference entryPoint
+        while ((hash = queue.poll()) != null) {
+            Set<Hash> approvers = ApproveeViewModel.load(tangle, hash).getHashes();
+            for (Hash tx : approvers) {
+                if (!rating.containsKey(tx)) {
+                    //add to rating w/ value "1"
+                    rating.put(tx, 1);
+                    queue.add(tx);
+                }
+            }
+        }
+        return rating;
+    }
+
+
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TailFinderImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TailFinderImpl.java
@@ -1,0 +1,48 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.service.tipselection.TailFinder;
+import com.iota.iri.storage.Tangle;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Implementation of <tt>TailFinder</tt> that given a transaction hash finds the tail of the associated bundle.
+ *
+ */
+public class TailFinderImpl implements TailFinder {
+
+    private final Tangle tangle;
+
+    public TailFinderImpl(Tangle tangle) {
+        this.tangle = tangle;
+    }
+
+    @Override
+    public Optional<Hash> findTail(Hash hash) throws Exception {
+        TransactionViewModel tx = TransactionViewModel.fromHash(tangle, hash);
+        final Hash bundleHash = tx.getBundleHash();
+        long index = tx.getCurrentIndex();
+        while (index-- > 0 && bundleHash.equals(tx.getBundleHash())) {
+            Set<Hash> approvees = tx.getApprovers(tangle).getHashes();
+            boolean foundApprovee = false;
+            for (Hash approvee : approvees) {
+                TransactionViewModel nextTx = TransactionViewModel.fromHash(tangle, approvee);
+                if (nextTx.getCurrentIndex() == index && bundleHash.equals(nextTx.getBundleHash())) {
+                    tx = nextTx;
+                    foundApprovee = true;
+                    break;
+                }
+            }
+            if (!foundApprovee) {
+                break;
+            }
+        }
+        if (tx.getCurrentIndex() == 0) {
+            return Optional.of(tx.getHash());
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -10,6 +10,7 @@ import com.iota.iri.storage.Tangle;
 import com.iota.iri.utils.collections.interfaces.UnIterableMap;
 import com.iota.iri.zmq.MessageQ;
 
+import java.security.InvalidAlgorithmParameterException;
 import java.security.SecureRandom;
 import java.util.*;
 
@@ -104,7 +105,7 @@ public class TipSelectorImpl implements TipSelector {
 
             //validate
             if (!ledgerValidator.checkConsistency(tips)) {
-                throw new RuntimeException(TIPS_NOT_CONSISTENT);
+                throw new IllegalStateException(TIPS_NOT_CONSISTENT);
             }
 
             return tips;
@@ -113,11 +114,10 @@ public class TipSelectorImpl implements TipSelector {
         }
     }
 
-    private void checkReference(HashId reference, UnIterableMap<HashId, Integer> rating) {
+    private void checkReference(HashId reference, UnIterableMap<HashId, Integer> rating)
+            throws InvalidAlgorithmParameterException {
         if (!rating.containsKey(reference)) {
-            throw new RuntimeException(REFERENCE_TRANSACTION_TOO_OLD);
+            throw new InvalidAlgorithmParameterException(REFERENCE_TRANSACTION_TOO_OLD);
         }
     }
-
-
 }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/TipSelectorImpl.java
@@ -1,0 +1,123 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.LedgerValidator;
+import com.iota.iri.Milestone;
+import com.iota.iri.TransactionValidator;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashId;
+import com.iota.iri.service.tipselection.*;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+import com.iota.iri.zmq.MessageQ;
+
+import java.security.SecureRandom;
+import java.util.*;
+
+/**
+ * Implementation of <tt>TipSelector</tt> that selects 2 tips,
+ * based on cumulative weights and transition function alpha.
+ *
+ */
+public class TipSelectorImpl implements TipSelector {
+
+    public static final String REFERENCE_TRANSACTION_TOO_OLD = "reference transaction is too old";
+    public static final String TIPS_NOT_CONSISTENT = "inconsistent tips pair selected";
+
+    private final EntryPointSelector entryPointSelector;
+    private final RatingCalculator ratingCalculator;
+    private final Walker walker;
+
+    private final int maxDepth;
+    private final LedgerValidator ledgerValidator;
+    private final TransactionValidator transactionValidator;
+    private final Tangle tangle;
+    private final Milestone milestone;
+
+    @Override
+    public int getMaxDepth() {
+        return maxDepth;
+    }
+
+    public TipSelectorImpl(Tangle tangle,
+                           LedgerValidator ledgerValidator,
+                           TransactionValidator transactionValidator,
+                           Milestone milestone,
+                           int maxDepth,
+                           MessageQ messageQ,
+                           boolean testnet,
+                           int milestoneStartIndex,
+                           double alpha) {
+
+        this.entryPointSelector = new EntryPointSelectorImpl(tangle, milestone, testnet, milestoneStartIndex);
+        this.ratingCalculator = new CumulativeWeightCalculator(tangle);
+
+        this.walker = new WalkerAlpha(alpha, new SecureRandom(), tangle, messageQ, new TailFinderImpl(tangle));
+
+        //used by walkValidator
+        this.maxDepth = maxDepth;
+        this.ledgerValidator = ledgerValidator;
+        this.transactionValidator = transactionValidator;
+        this.tangle = tangle;
+        this.milestone = milestone;
+    }
+
+    /**
+     * Implementation of getTransactionsToApprove
+     *
+     * General process:
+     * <ol>
+     * <li><b>Preparation:</b> select <CODE>entryPoint</CODE> and calculate rating for all referencing transactions
+     * <li><b>1st Random Walk:</b> starting from <CODE>entryPoint</CODE>.
+     * <li><b>2nd Random Walk:</b> if <CODE>reference</CODE> exists and is in the rating calulationg, start from <CODE>reference</CODE>,
+     *     otherwise start again from <CODE>entryPoint</CODE>.
+     * <li><b>Validate:</b> check that both tips are not contradicting.
+     * </ol>
+     * @param depth  The depth that the transactions will be found from.
+     * @param reference  An optional transaction hash to be referenced by tips.
+     * @return  Transactions to approve
+     * @throws Exception If DB fails to retrieve transactions
+     */
+    @Override
+    public List<Hash> getTransactionsToApprove(int depth, Optional<Hash> reference) throws Exception {
+        try {
+            milestone.latestSnapshot.rwlock.readLock().lock();
+
+            //preparation
+            Hash entryPoint = entryPointSelector.getEntryPoint(depth);
+            UnIterableMap<HashId, Integer> rating = ratingCalculator.calculate(entryPoint);
+
+            //random walk
+            List<Hash> tips = new LinkedList<>();
+            WalkValidator walkValidator = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator, milestone,
+                    maxDepth);
+            Hash tip = walker.walk(entryPoint, rating, walkValidator);
+            tips.add(tip);
+
+            if (reference.isPresent()) {
+                checkReference(reference.get(), rating);
+                entryPoint = reference.get();
+            }
+
+            //passing the same walkValidator means that the walks will be consistent with each other
+            tip = walker.walk(entryPoint, rating, walkValidator);
+            tips.add(tip);
+
+            //validate
+            if (!ledgerValidator.checkConsistency(tips)) {
+                throw new RuntimeException(TIPS_NOT_CONSISTENT);
+            }
+
+            return tips;
+        } finally {
+            milestone.latestSnapshot.rwlock.readLock().unlock();
+        }
+    }
+
+    private void checkReference(HashId reference, UnIterableMap<HashId, Integer> rating) {
+        if (!rating.containsKey(reference)) {
+            throw new RuntimeException(REFERENCE_TRANSACTION_TOO_OLD);
+        }
+    }
+
+
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
@@ -1,0 +1,107 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.LedgerValidator;
+import com.iota.iri.TransactionValidator;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.Milestone;
+import com.iota.iri.service.tipselection.WalkValidator;
+import com.iota.iri.storage.Tangle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * Implementation of <tt>WalkValidator</tt> that checks consistency of the ledger as part of validity checks.
+ *
+ *     A transaction is only valid if:
+ *      <ol>
+ *      <li>it is a tail
+ *      <li>all the history of the transaction is present (is solid)
+ *      <li>it does not reference an old unconfirmed transaction (not belowMaxDepth)
+ *      <li>the ledger is still consistent if the transaction is added
+ *          (balances of all addresses are correct and all signatures are valid)
+ *      </ol>
+ */
+public class WalkValidatorImpl implements WalkValidator {
+
+    private final Tangle tangle;
+    private final Logger log = LoggerFactory.getLogger(WalkValidator.class);
+    private final LedgerValidator ledgerValidator;
+    private final TransactionValidator transactionValidator;
+    private final Milestone milestone;
+
+    private final int maxDepth;
+
+    private Set<Hash> maxDepthOkMemoization;
+    private Map<Hash, Long> myDiff;
+    private Set<Hash> myApprovedHashes;
+
+    public WalkValidatorImpl(Tangle tangle, LedgerValidator ledgerValidator, TransactionValidator transactionValidator,
+                             Milestone milestone, int maxDepth) {
+        this.tangle = tangle;
+        this.ledgerValidator = ledgerValidator;
+        this.transactionValidator = transactionValidator;
+        this.milestone = milestone;
+        this.maxDepth = maxDepth;
+
+        maxDepthOkMemoization = new HashSet<>();
+        myDiff = new HashMap<>();
+        myApprovedHashes = new HashSet<>();
+    }
+
+    @Override
+    public boolean isValid(Hash transactionHash) throws Exception {
+
+        TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, transactionHash);
+
+        if (transactionViewModel.getType() == TransactionViewModel.PREFILLED_SLOT) {
+            log.debug("Validation failed: {} is missing in db", transactionHash);
+            return false;
+        } else if (transactionViewModel.getCurrentIndex() != 0) {
+            log.debug("Validation failed: {} not a tail", transactionHash);
+            return false;
+        } else if (!transactionValidator.checkSolidity(transactionViewModel.getHash(), false)) {
+            log.debug("Validation failed: {} is not solid", transactionHash);
+            return false;
+        } else if (belowMaxDepth(transactionViewModel.getHash(), milestone.latestSolidSubtangleMilestoneIndex - maxDepth)) {
+            log.debug("Validation failed: {} is below max depth", transactionHash);
+            return false;
+        } else if (!ledgerValidator.updateDiff(myApprovedHashes, myDiff, transactionViewModel.getHash())) {
+            log.debug("Validation failed: {} is not consistent", transactionHash);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean belowMaxDepth(Hash tip, int depth) throws Exception {
+        //if tip is confirmed stop
+        if (TransactionViewModel.fromHash(tangle, tip).snapshotIndex() >= depth) {
+            return false;
+        }
+        //if tip unconfirmed, check if any referenced tx is confirmed below maxDepth
+        Queue<Hash> nonAnalyzedTransactions = new LinkedList<>(Collections.singleton(tip));
+        Set<Hash> analyzedTransactions = new HashSet<>();
+        Hash hash;
+        while ((hash = nonAnalyzedTransactions.poll()) != null) {
+            if (analyzedTransactions.add(hash)) {
+                TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);
+                if (transaction.snapshotIndex() != 0 && transaction.snapshotIndex() < depth) {
+                    return true;
+                }
+                if (transaction.snapshotIndex() == 0) {
+                    if (maxDepthOkMemoization.contains(hash)) {
+                        //log.info("Memoization!");
+                    }
+                    else {
+                        nonAnalyzedTransactions.offer(transaction.getTrunkTransactionHash());
+                        nonAnalyzedTransactions.offer(transaction.getBranchTransactionHash());
+                    }
+                }
+            }
+        }
+        maxDepthOkMemoization.add(tip);
+        return false;
+    }
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkValidatorImpl.java
@@ -91,10 +91,7 @@ public class WalkValidatorImpl implements WalkValidator {
                     return true;
                 }
                 if (transaction.snapshotIndex() == 0) {
-                    if (maxDepthOkMemoization.contains(hash)) {
-                        //log.info("Memoization!");
-                    }
-                    else {
+                    if (!maxDepthOkMemoization.contains(hash)) {
                         nonAnalyzedTransactions.offer(transaction.getTrunkTransactionHash());
                         nonAnalyzedTransactions.offer(transaction.getBranchTransactionHash());
                     }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
@@ -50,7 +50,7 @@ public class WalkerAlpha implements Walker {
     @Override
     public Hash walk(Hash entryPoint, UnIterableMap<HashId, Integer> ratings, WalkValidator walkValidator) throws Exception {
         if (!walkValidator.isValid(entryPoint)) {
-            throw new RuntimeException("entry point failed consistency check: " + entryPoint.toString());
+            throw new IllegalStateException("entry point failed consistency check: " + entryPoint.toString());
         }
         
         Optional<Hash> nextStep;
@@ -135,12 +135,9 @@ public class WalkerAlpha implements Walker {
 
     private Optional<Hash> findTailIfValid(Hash transactionHash, WalkValidator validator) throws Exception {
         Optional<Hash> tailHash = tailFinder.findTail(transactionHash);
-        if (tailHash.isPresent()) {
-            if (validator.isValid(tailHash.get())) {
+        if (tailHash.isPresent() && validator.isValid(tailHash.get())) {
                 return tailHash;
-            }
         }
-
         return Optional.empty();
     }
 }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/WalkerAlpha.java
@@ -1,0 +1,146 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.controllers.ApproveeViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashId;
+import com.iota.iri.service.tipselection.TailFinder;
+import com.iota.iri.service.tipselection.WalkValidator;
+import com.iota.iri.service.tipselection.Walker;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+import com.iota.iri.zmq.MessageQ;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of <tt>Walker</tt> that performs a weighted random walk
+ * with <CODE>e^(alpha*Hy)</CODE> as the transition function.
+ *
+ */
+public class WalkerAlpha implements Walker {
+
+    private double alpha;
+    private final Random random;
+
+    private final Tangle tangle;
+    private final MessageQ messageQ;
+    private final Logger log = LoggerFactory.getLogger(Walker.class);
+
+    private final TailFinder tailFinder;
+
+    public WalkerAlpha(double alpha, Random random, Tangle tangle, MessageQ messageQ, TailFinder tailFinder) {
+        this.alpha = alpha;
+        this.random = random;
+        this.tangle = tangle;
+        this.messageQ = messageQ;
+        this.tailFinder = tailFinder;
+    }
+
+    public double getAlpha() {
+        return alpha;
+    }
+
+    public void setAlpha(double alpha) {
+        this.alpha = alpha;
+    }
+
+    @Override
+    public Hash walk(Hash entryPoint, UnIterableMap<HashId, Integer> ratings, WalkValidator walkValidator) throws Exception {
+        if (!walkValidator.isValid(entryPoint)) {
+            throw new RuntimeException("entry point failed consistency check: " + entryPoint.toString());
+        }
+        
+        Optional<Hash> nextStep;
+        Deque<Hash> traversedTails = new LinkedList<>();
+        traversedTails.add(entryPoint);
+
+        //Walk
+        do {
+            nextStep = selectApprover(traversedTails.getLast(), ratings, walkValidator);
+            nextStep.ifPresent(traversedTails::add);
+         } while (nextStep.isPresent());
+        
+        log.debug("{} tails traversed to find tip", traversedTails.size());
+        messageQ.publish("mctn %d", traversedTails.size());
+
+        return traversedTails.getLast();
+    }
+
+    private Optional<Hash> selectApprover(Hash tailHash, UnIterableMap<HashId, Integer> ratings, WalkValidator walkValidator) throws Exception {
+        Set<Hash> approvers = getApprovers(tailHash);
+        return findNextValidTail(ratings, approvers, walkValidator);
+    }
+
+    private Set<Hash> getApprovers(Hash tailHash) throws Exception {
+        ApproveeViewModel approveeViewModel = ApproveeViewModel.load(tangle, tailHash);
+        return approveeViewModel.getHashes();
+    }
+
+    private Optional<Hash> findNextValidTail(UnIterableMap<HashId, Integer> ratings, Set<Hash> approvers, WalkValidator walkValidator) throws Exception {
+        Optional<Hash> nextTailHash = Optional.empty();
+
+        //select next tail to step to
+        while (!nextTailHash.isPresent()) {
+            Optional<Hash> nextTxHash = select(ratings, approvers);
+            if (!nextTxHash.isPresent()) {
+                //no existing approver = tip
+                return Optional.empty();
+            }
+
+            nextTailHash = findTailIfValid(nextTxHash.get(), walkValidator);
+            approvers.remove(nextTxHash.get());
+            //if next tail is not valid, re-select while removing it from approvers set
+        }
+
+        return nextTailHash;
+    }
+
+    private Optional<Hash> select(UnIterableMap<HashId, Integer> ratings, Set<Hash> approversSet) {
+
+        //filter based on tangle state when starting the walk
+        List<Hash> approvers = approversSet.stream().filter(ratings::containsKey).collect(Collectors.toList());
+
+        //After filtering, if no approvers are available, it's a tip.
+        if (approvers.size() == 0) {
+            return Optional.empty();
+        }
+
+        //calculate the probabilities
+        List<Integer> walkRatings = approvers.stream().map(ratings::get).collect(Collectors.toList());
+
+        Integer maxRating = walkRatings.stream().max(Integer::compareTo).orElse(0);
+        //walkRatings.stream().reduce(0, Integer::max);
+
+        //transition probability function (normalize ratings based on Hmax)
+        List<Integer> normalizedWalkRatings = walkRatings.stream().map(w -> w - maxRating).collect(Collectors.toList());
+        List<Double> weights = normalizedWalkRatings.stream().map(w -> Math.exp(alpha * w)).collect(Collectors.toList());
+
+        //select the next transaction
+        Double weightsSum = weights.stream().reduce(0.0, Double::sum);
+        double target = random.nextDouble() * weightsSum;
+
+        int approverIndex;
+        for (approverIndex = 0; approverIndex < weights.size() - 1; approverIndex++) {
+            target -= weights.get(approverIndex);
+            if (target <= 0) {
+                break;
+            }
+        }
+
+        return Optional.of(approvers.get(approverIndex));
+    }
+
+    private Optional<Hash> findTailIfValid(Hash transactionHash, WalkValidator validator) throws Exception {
+        Optional<Hash> tailHash = tailFinder.findTail(transactionHash);
+        if (tailHash.isPresent()) {
+            if (validator.isValid(tailHash.get())) {
+                return tailHash;
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/iota/iri/utils/collections/impl/TransformingBoundedHashSet.java
+++ b/src/main/java/com/iota/iri/utils/collections/impl/TransformingBoundedHashSet.java
@@ -22,19 +22,22 @@ public class TransformingBoundedHashSet<E> extends BoundedHashSet<E>{
 
     @Override
     public boolean add(E e) {
-        if (!isFull()) {
-            e = transformer.apply(e);
+        if (isFull()) {
+            return false;
         }
-        return super.add(e);
+
+        E el = transformer.apply(e);
+        return super.add(el);
     }
 
     @Override
     public boolean addAll(Collection<? extends E> c) {
+        Collection<? extends E> col = c;
         if (!isFull()) {
-            c = c.stream()
+            col = c.stream()
                     .map(el -> transformer.apply(el))
                     .collect(Collectors.toSet());
         }
-        return super.addAll(c);
+        return super.addAll(col);
     }
 }

--- a/src/main/java/com/iota/iri/utils/collections/impl/TransformingBoundedHashSet.java
+++ b/src/main/java/com/iota/iri/utils/collections/impl/TransformingBoundedHashSet.java
@@ -1,0 +1,40 @@
+package com.iota.iri.utils.collections.impl;
+
+import java.util.Collection;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+
+public class TransformingBoundedHashSet<E> extends BoundedHashSet<E>{
+
+    private final UnaryOperator<E> transformer;
+
+    public TransformingBoundedHashSet(int maxSize, UnaryOperator<E> transformer) {
+        super(maxSize);
+        this.transformer = transformer;
+    }
+
+    public TransformingBoundedHashSet(Collection<E> c, int maxSize, UnaryOperator<E> transformer) {
+        super(maxSize);
+        this.transformer = transformer;
+        this.addAll(c);
+    }
+
+    @Override
+    public boolean add(E e) {
+        if (!isFull()) {
+            e = transformer.apply(e);
+        }
+        return super.add(e);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        if (!isFull()) {
+            c = c.stream()
+                    .map(el -> transformer.apply(el))
+                    .collect(Collectors.toSet());
+        }
+        return super.addAll(c);
+    }
+}

--- a/src/main/java/com/iota/iri/utils/collections/impl/TransformingMap.java
+++ b/src/main/java/com/iota/iri/utils/collections/impl/TransformingMap.java
@@ -1,0 +1,80 @@
+package com.iota.iri.utils.collections.impl;
+
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+/**
+ * A map that performs unary operations on key-value pairs that are inserted into it.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class TransformingMap<K,V> implements UnIterableMap<K,V> {
+    private Map<K,V> delegateMap;
+    private UnaryOperator<K> keyOptimizer;
+    private UnaryOperator<V> valueTransformer;
+
+    public TransformingMap(UnaryOperator<K> keyOptimizer, UnaryOperator<V> valueTransformer) {
+        this(16, keyOptimizer, valueTransformer);
+    }
+
+    public TransformingMap(int initialCapacity, UnaryOperator<K> keyOptimizer, UnaryOperator<V> valueTransformer) {
+        this.keyOptimizer = keyOptimizer == null ? UnaryOperator.identity() : keyOptimizer;
+        this.valueTransformer = valueTransformer == null ? UnaryOperator.identity() : valueTransformer;
+
+        this.delegateMap = new HashMap<>(initialCapacity);
+    }
+
+    @Override
+    public int size() {
+        return delegateMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegateMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        K newKey = keyOptimizer.apply(key);
+        return delegateMap.containsKey(newKey);
+    }
+
+    @Override
+    public boolean containsValue(V value) {
+        return delegateMap.containsValue(value);
+    }
+
+    @Override
+    public V get(K key) {
+        K newKey = keyOptimizer.apply(key);
+        return delegateMap.get(newKey);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        key = keyOptimizer.apply(key);
+        value = valueTransformer.apply(value);
+        return delegateMap.put(key, value);
+    }
+
+    @Override
+    public V remove(K key) {
+        return delegateMap.remove(key);
+    }
+
+    @Override
+    public void clear() {
+        delegateMap.clear();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return delegateMap.values();
+    }
+}

--- a/src/main/java/com/iota/iri/utils/collections/interfaces/UnIterableMap.java
+++ b/src/main/java/com/iota/iri/utils/collections/interfaces/UnIterableMap.java
@@ -1,0 +1,63 @@
+package com.iota.iri.utils.collections.interfaces;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+/**
+ * Similar to {@link Map} but hides key retrieval functionality.
+ * Thus one can't iterate over key or entries.
+ * Implementing class may transform keys to perform memory operations
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
+public interface UnIterableMap<K,V> {
+
+
+    /**
+     * {See {@link Map#size()}}
+     */
+    int size();
+
+    /**
+     * {See {@link Map#isEmpty()}}
+     */
+    boolean isEmpty();
+
+    /**
+     * {See {@link Map#containsKey(Object)}}
+     */
+    boolean containsKey(K key);
+
+    /**
+     * {See {@link Map#containsValue(Object)}}
+     */
+    boolean containsValue(V value);
+
+    /**
+     *
+     * {See {@link Map#get}}
+     */
+    V get(K key);
+
+    /**
+     * {See {@link Map#put}
+     */
+    V put(K key, V value);
+
+    /**
+     * {See {@link Map#keySet()}}
+     */
+    V remove(K key);
+
+    /**
+     * {See {@link Map#clear()}}
+     */
+    void clear();
+
+    /**
+     * {See {@link Map#values}
+     */
+    Collection<V> values();
+}

--- a/src/test/java/com/iota/iri/TransactionTestUtils.java
+++ b/src/test/java/com/iota/iri/TransactionTestUtils.java
@@ -1,0 +1,37 @@
+package com.iota.iri;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.controllers.TransactionViewModelTest;
+import com.iota.iri.model.Hash;
+import com.iota.iri.utils.Converter;
+
+public class TransactionTestUtils {
+
+    public static void setCurrentIndex(TransactionViewModel tx, long currentIndex) {
+        Converter.copyTrits(currentIndex, tx.trits(), TransactionViewModel.CURRENT_INDEX_TRINARY_OFFSET,
+                TransactionViewModel.CURRENT_INDEX_TRINARY_SIZE);
+    }
+
+    public static void setLastIndex(TransactionViewModel tx, long lastIndex) {
+        Converter.copyTrits(lastIndex, tx.trits(), TransactionViewModel.LAST_INDEX_TRINARY_OFFSET,
+                TransactionViewModel.LAST_INDEX_TRINARY_SIZE);
+    }
+
+    public static TransactionViewModel createBundleHead(int index) {
+        TransactionViewModel tx = new TransactionViewModel(TransactionViewModelTest.getRandomTransactionTrits(), TransactionViewModelTest.getRandomTransactionHash());
+        setLastIndex(tx, index);
+        setCurrentIndex(tx, index);
+        return tx;
+    }
+
+    public static TransactionViewModel createTransactionWithTrunkBundleHash(TransactionViewModel trunkTx, Hash branchHash) {
+        TransactionViewModel tx = new TransactionViewModel(
+                TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch(trunkTx.getHash(), branchHash),
+                TransactionViewModelTest.getRandomTransactionHash());
+        setCurrentIndex(tx, trunkTx.getCurrentIndex() - 1);
+        setLastIndex(tx, trunkTx.lastIndex());
+        System.arraycopy(trunkTx.trits(), TransactionViewModel.BUNDLE_TRINARY_OFFSET, tx.trits(),
+                TransactionViewModel.BUNDLE_TRINARY_OFFSET, TransactionViewModel.BUNDLE_TRINARY_SIZE);
+        return tx;
+    }
+}

--- a/src/test/java/com/iota/iri/controllers/TransactionViewModelTest.java
+++ b/src/test/java/com/iota/iri/controllers/TransactionViewModelTest.java
@@ -1,6 +1,7 @@
 package com.iota.iri.controllers;
 
 import com.iota.iri.conf.Configuration;
+import com.iota.iri.hash.Sponge;
 import com.iota.iri.hash.SpongeFactory;
 import com.iota.iri.model.Hash;
 import com.iota.iri.model.Transaction;
@@ -406,6 +407,30 @@ public class TransactionViewModelTest {
                 TransactionViewModel.TRUNK_TRANSACTION_TRINARY_SIZE);
         System.arraycopy(branch.trits(), 0, trits, TransactionViewModel.BRANCH_TRANSACTION_TRINARY_OFFSET,
                 TransactionViewModel.BRANCH_TRANSACTION_TRINARY_SIZE);
+        return trits;
+    }
+    public static int[] getRandomTransactionWithTrunkAndBranchValidBundle(Hash trunk, Hash branch) {
+        int[] trits = getRandomTransactionTrits();
+        System.arraycopy(trunk.trits(), 0, trits, TransactionViewModel.TRUNK_TRANSACTION_TRINARY_OFFSET,
+                TransactionViewModel.TRUNK_TRANSACTION_TRINARY_SIZE);
+        System.arraycopy(branch.trits(), 0, trits, TransactionViewModel.BRANCH_TRANSACTION_TRINARY_OFFSET,
+                TransactionViewModel.BRANCH_TRANSACTION_TRINARY_SIZE);
+        System.arraycopy(Hash.NULL_HASH.trits(), 0, trits, TransactionViewModel.CURRENT_INDEX_TRINARY_OFFSET,
+                TransactionViewModel.CURRENT_INDEX_TRINARY_SIZE);
+        System.arraycopy(Hash.NULL_HASH.trits(), 0, trits, TransactionViewModel.LAST_INDEX_TRINARY_OFFSET,
+                TransactionViewModel.LAST_INDEX_TRINARY_SIZE);
+        System.arraycopy(Hash.NULL_HASH.trits(), 0, trits, TransactionViewModel.VALUE_TRINARY_OFFSET,
+                TransactionViewModel.VALUE_TRINARY_SIZE);
+
+        final Sponge curlInstance = SpongeFactory.create(SpongeFactory.Mode.KERL);
+        final int[] bundleHashTrits = new int[TransactionViewModel.BUNDLE_TRINARY_SIZE];
+        curlInstance.reset();
+        curlInstance.absorb(trits, TransactionViewModel.ESSENCE_TRINARY_OFFSET, TransactionViewModel.ESSENCE_TRINARY_SIZE);
+        curlInstance.squeeze(bundleHashTrits, 0, bundleHashTrits.length);
+
+        System.arraycopy(bundleHashTrits, 0, trits, TransactionViewModel.BUNDLE_TRINARY_OFFSET,
+                TransactionViewModel.BUNDLE_TRINARY_SIZE);
+
         return trits;
     }
     public static int[] getRandomTransactionTrits() {

--- a/src/test/java/com/iota/iri/service/tipselection/impl/CumulativeWeightCalculatorTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/CumulativeWeightCalculatorTest.java
@@ -1,18 +1,13 @@
-package com.iota.iri.service;
+package com.iota.iri.service.tipselection.impl;
 
-import com.iota.iri.LedgerValidator;
-import com.iota.iri.Milestone;
-import com.iota.iri.Snapshot;
-import com.iota.iri.TransactionValidator;
-import com.iota.iri.conf.Configuration;
-import com.iota.iri.controllers.TipsViewModel;
+
+import com.iota.iri.controllers.ApproveeViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
-import com.iota.iri.network.TransactionRequester;
+import com.iota.iri.model.HashId;
 import com.iota.iri.storage.Tangle;
 import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
-import com.iota.iri.utils.IotaUtils;
-import com.iota.iri.zmq.MessageQ;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -21,39 +16,24 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.Buffer;
 import java.util.*;
 
-import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionHash;
-import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionTrits;
-import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch;
+import static com.iota.iri.controllers.TransactionViewModelTest.*;
 
-/**
- * Created by paul on 4/27/17.
- */
-public class TipsManagerTest {
-
+public class CumulativeWeightCalculatorTest {
     private static final TemporaryFolder dbFolder = new TemporaryFolder();
     private static final TemporaryFolder logFolder = new TemporaryFolder();
     private static final String TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT =
             "tx%d cumulative weight is not as expected";
     private static Tangle tangle;
-    private static TipsManager tipsManager;
+    private static CumulativeWeightCalculator cumulativeWeightCalculator;
     private final Logger log = LoggerFactory.getLogger(this.getClass());
-
-    @Test
-    public void capSum() {
-        long a = 0, b, max = Long.MAX_VALUE / 2;
-        for (b = 0; b < max; b += max / 100) {
-            a = TipsManager.capSum(a, b, max);
-            Assert.assertTrue("a should never go above max", a <= max);
-        }
-    }
 
     @AfterClass
     public static void tearDown() throws Exception {
         tangle.shutdown();
         dbFolder.delete();
+        logFolder.delete();
     }
 
     @BeforeClass
@@ -64,20 +44,7 @@ public class TipsManagerTest {
         tangle.addPersistenceProvider(new RocksDBPersistenceProvider(dbFolder.getRoot().getAbsolutePath(), logFolder
                 .getRoot().getAbsolutePath(), 1000));
         tangle.init();
-        TipsViewModel tipsViewModel = new TipsViewModel();
-        MessageQ messageQ = new MessageQ(0, null, 1, false);
-        TransactionRequester transactionRequester = new TransactionRequester(tangle, messageQ);
-        TransactionValidator transactionValidator = new TransactionValidator(tangle, tipsViewModel, transactionRequester,
-                messageQ, Long.parseLong(Configuration.GLOBAL_SNAPSHOT_TIME));
-        int milestoneStartIndex = Integer.parseInt(Configuration.MAINNET_MILESTONE_START_INDEX);
-        int numOfKeysInMilestone = Integer.parseInt(Configuration.MAINNET_NUM_KEYS_IN_MILESTONE);
-        Milestone milestone = new Milestone(tangle, Hash.NULL_HASH, Snapshot.init(
-                Configuration.MAINNET_SNAPSHOT_FILE, Configuration.MAINNET_SNAPSHOT_SIG_FILE, false).clone(),
-                transactionValidator, false, messageQ, numOfKeysInMilestone,
-                milestoneStartIndex, true);
-        LedgerValidator ledgerValidator = new LedgerValidator(tangle, milestone, transactionRequester, messageQ);
-        tipsManager = new TipsManager(tangle, ledgerValidator, transactionValidator, tipsViewModel, milestone,
-                15, messageQ, false, milestoneStartIndex);
+        cumulativeWeightCalculator = new CumulativeWeightCalculator(tangle);
     }
 
     @Test
@@ -97,19 +64,18 @@ public class TipsManagerTest {
         transaction2.store(tangle);
         transaction3.store(tangle);
         transaction4.store(tangle);
-        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
-                transaction.getHash(), false, new HashSet<>());
+        UnIterableMap<HashId, Integer> txToCw = cumulativeWeightCalculator.calculate(transaction.getHash());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                1, txToCw.get(IotaUtils.getSubHash(transaction4.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                1, txToCw.get(transaction4.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                2, txToCw.get(IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                2, txToCw.get(transaction3.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                3, txToCw.get(transaction2.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                4, txToCw.get(IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                4, txToCw.get(transaction1.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                5, txToCw.get(IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                5, txToCw.get(transaction.getHash()).intValue());
     }
 
     @Test
@@ -126,22 +92,22 @@ public class TipsManagerTest {
         transaction1.store(tangle);
         transaction2.store(tangle);
         transaction3.store(tangle);
+
         log.debug("printing transaction in diamond shape \n                      {} \n{}  {}\n                      {}",
                 transaction.getHash(), transaction1.getHash(), transaction2.getHash(), transaction3.getHash());
-        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
-                transaction.getHash(), false, new HashSet<>());
+        UnIterableMap<HashId, Integer> txToCw = cumulativeWeightCalculator.calculate(transaction.getHash());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                1, txToCw.get(IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH))
+                1, txToCw.get(transaction3.getHash())
                         .intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                2, txToCw.get(IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH))
+                2, txToCw.get(transaction1.getHash())
                         .intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                2, txToCw.get(IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH))
+                2, txToCw.get(transaction2.getHash())
                         .intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                4, txToCw.get(IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                4, txToCw.get(transaction.getHash()).intValue());
     }
 
     @Test
@@ -165,24 +131,23 @@ public class TipsManagerTest {
         log.info(String.format("Linear ordered hashes from tip %.4s, %.4s, %.4s, %.4s, %.4s", transaction4.getHash(),
                 transaction3.getHash(), transaction2.getHash(), transaction1.getHash(), transaction.getHash()));
 
-        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
-                transaction.getHash(), false, new HashSet<>());
+        UnIterableMap<HashId, Integer> txToCw = cumulativeWeightCalculator.calculate(transaction.getHash());
 
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                1, txToCw.get(IotaUtils.getSubHash(transaction4.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                1, txToCw.get(transaction4.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                2, txToCw.get(IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                2, txToCw.get(transaction3.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                3, txToCw.get(transaction2.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                4, txToCw.get(IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                4, txToCw.get(transaction1.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                5, txToCw.get(IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                5, txToCw.get(transaction.getHash()).intValue());
     }
 
     @Test
-    public void testCalculateCumulativeWeightAlon() throws Exception {
+    public void testCalculateCumulativeWeight2() throws Exception {
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4, transaction5,
                 transaction6;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
@@ -211,23 +176,22 @@ public class TipsManagerTest {
                 transaction.getHash(), transaction1.getHash(), transaction2.getHash(), transaction3.getHash(),
                 transaction4, transaction5, transaction6);
 
-        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
-                transaction.getHash(), false, new HashSet<>());
+        UnIterableMap<HashId, Integer> txToCw = cumulativeWeightCalculator.calculate(transaction.getHash());
 
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 6),
-                1, txToCw.get(IotaUtils.getSubHash(transaction6.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                1, txToCw.get(transaction6.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 5),
-                2, txToCw.get(IotaUtils.getSubHash(transaction5.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                2, txToCw.get(transaction5.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 4),
-                2, txToCw.get(IotaUtils.getSubHash(transaction4.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                2, txToCw.get(transaction4.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
-                3, txToCw.get(IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                3, txToCw.get(transaction3.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
-                3, txToCw.get(IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                3, txToCw.get(transaction2.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
-                1, txToCw.get(IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                1, txToCw.get(transaction1.getHash()).intValue());
         Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
-                7, txToCw.get(IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+                7, txToCw.get(transaction.getHash()).intValue());
     }
 
     @Test
@@ -248,60 +212,96 @@ public class TipsManagerTest {
                     transactionViewModel.getTrunkTransactionHash(),
                     transactionViewModel.getBranchTransactionHash()));
         }
-        Map<Hash, Set<Hash>> ratings = new HashMap<>();
+        Map<HashId, Set<HashId>> ratings = new HashMap<>();
         updateApproversRecursively(hashes[0], ratings, new HashSet<>());
-        Map<Buffer, Integer> txToCw = tipsManager.calculateCumulativeWeight(new HashSet<>(),
-                hashes[0], false, new HashSet<>());
+        UnIterableMap<HashId, Integer> txToCw = cumulativeWeightCalculator.calculate(hashes[0]);
 
         Assert.assertEquals("missing txs from new calculation", ratings.size(), txToCw.size());
         ratings.forEach((hash, weight) -> {
             log.debug(String.format("tx %.4s has expected weight of %d", hash, weight.size()));
             Assert.assertEquals(
                     "new calculation weight is not as expected for hash " + hash,
-                    weight.size(), txToCw.get(IotaUtils.getSubHash(hash, TipsManager.SUBHASH_LENGTH))
+                    weight.size(), txToCw.get(hash)
                             .intValue());
         });
     }
 
     @Test
-    public void testCalculateCommulativeWeightWithLeftBehind() throws Exception {
+    public void testTangleWithCircle() throws Exception {
+        TransactionViewModel transaction;
+        Hash randomTransactionHash = getRandomTransactionHash();
+        transaction = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(randomTransactionHash, randomTransactionHash), randomTransactionHash);
+
+        transaction.store(tangle);
+
+        UnIterableMap<HashId, Integer> txToCw = cumulativeWeightCalculator.calculate(transaction.getHash());
+        Assert.assertEquals("There should be only one tx in the map", 1, txToCw.size());
+        Assert.assertEquals("The circle raised the weight", 1, txToCw.get(randomTransactionHash).intValue());
+    }
+
+    @Test
+    public void testTangleWithCircle2() throws Exception {
         TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
+        Hash randomTransactionHash2 = getRandomTransactionHash();
+        transaction = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+                randomTransactionHash2, randomTransactionHash2), getRandomTransactionHash());
+        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+                transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+                transaction1.getHash(), transaction1.getHash()), randomTransactionHash2);
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+                transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
+
+        transaction.store(tangle);
+        transaction1.store(tangle);
+        transaction2.store(tangle);
+        transaction3.store(tangle);
+
+        cumulativeWeightCalculator.calculate(transaction.getHash());
+        //No infinite loop (which will probably result in an overflow exception) means test has passed
+    }
+
+    @Test
+    public void testCollsionsInDiamondTangle() throws Exception {
+        TransactionViewModel transaction, transaction1, transaction2, transaction3;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
         transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());
-        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
-                transaction.getHash()), getRandomTransactionHash());
-        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
-                transaction.getHash()), getRandomTransactionHash());
-        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction3.getHash(),
-                transaction1.getHash()), getRandomTransactionHash());
-        Set<Hash> approvedHashes = new HashSet<>();
+        Hash transactionHash2 = getHashWithSimilarPrefix(transaction1);
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), transactionHash2);
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+                transaction2.getHash()), getRandomTransactionHash());
         transaction.store(tangle);
         transaction1.store(tangle);
-        approvedHashes.add(transaction2.getHash());
         transaction2.store(tangle);
-        approvedHashes.add(transaction3.getHash());
         transaction3.store(tangle);
-        transaction4.store(tangle);
 
-        Map<Buffer, Integer> cumulativeWeight = tipsManager.calculateCumulativeWeight(approvedHashes,
-                transaction.getHash(), true, new HashSet<>());
+        log.debug("printing transaction in diamond shape \n                      {} \n{}  {}\n                      {}",
+                transaction.getHash(), transaction1.getHash(), transaction2.getHash(), transaction3.getHash());
+        UnIterableMap<HashId, Integer> txToCw = cumulativeWeightCalculator.calculate(transaction.getHash());
 
-        log.info(cumulativeWeight.toString());
-        String msg = "Cumulative weight is wrong for tx";
-        Assert.assertEquals(msg + 4, 1, cumulativeWeight.get(
-                IotaUtils.getSubHash(transaction4.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
-        Assert.assertEquals(msg + 3, 1, cumulativeWeight.get(
-                IotaUtils.getSubHash(transaction3.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
-        Assert.assertEquals(msg + 2, 1, cumulativeWeight.get(
-                IotaUtils.getSubHash(transaction2.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
-        Assert.assertEquals(msg + 1, 2, cumulativeWeight.get(
-                IotaUtils.getSubHash(transaction1.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
-        Assert.assertEquals(msg + 0, 3, cumulativeWeight.get(
-                IotaUtils.getSubHash(transaction.getHash(), TipsManager.SUBHASH_LENGTH)).intValue());
+        Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 3),
+                1, txToCw.get(transaction3.getHash()).intValue());
+        Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 1),
+                2, txToCw.get(transaction1.getHash()).intValue());
+        Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 2),
+                2, txToCw.get(transaction2.getHash()).intValue());
+        //expected to not count 1 of the parents due to collision
+        Assert.assertEquals(String.format(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT, 0),
+                3, txToCw.get(transaction.getHash()).intValue());
     }
 
-    //    @Test
+    private Hash getHashWithSimilarPrefix(TransactionViewModel transaction1) {
+        Hash transactionHash1 = transaction1.getHash();
+        byte[] bytes = transactionHash1.bytes();
+        bytes =  Arrays.copyOf(bytes, bytes.length);
+        Arrays.fill(bytes, bytes.length-5, bytes.length-1, (byte)1);
+        return new Hash(bytes);
+    }
+
+
+    // @Test
     //To be removed once CI tests are ready
     public void testUpdateRatingsTime() throws Exception {
         int max = 100001;
@@ -324,24 +324,21 @@ public class TipsManagerTest {
             new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(hashes[i - random.nextInt(i) - 1],
                     hashes[i - random.nextInt(i) - 1]), hashes[i]).store(tangle);
         }
-        Map<Hash, Long> ratings = new HashMap<>();
         long start = System.currentTimeMillis();
-//        tipsManager.serialUpdateRatings(new Snapshot(Snapshot.initialSnapshot), hashes[0], ratings, new HashSet<>()
-// , null);
-        tipsManager.calculateCumulativeWeight(new HashSet<>(), hashes[0], false, new HashSet<>());
+
+        cumulativeWeightCalculator.calculate(hashes[0]);
         long time = System.currentTimeMillis() - start;
         System.out.println(time);
         return time;
     }
 
     //Simple recursive algorithm that maps each tx hash to its approvers' hashes
-    private static Set<Hash> updateApproversRecursively(Hash txHash, Map<Hash, Set<Hash>> txToApprovers,
-            Set<Hash> analyzedTips) throws Exception {
-        Set<Hash> approvers;
+    private static Set<HashId> updateApproversRecursively(Hash txHash, Map<HashId, Set<HashId>> txToApprovers,
+                                                        Set<HashId> analyzedTips) throws Exception {
+        Set<HashId> approvers;
         if (analyzedTips.add(txHash)) {
-            TransactionViewModel transactionViewModel = TransactionViewModel.fromHash(tangle, txHash);
             approvers = new HashSet<>(Collections.singleton(txHash));
-            Set<Hash> approverHashes = transactionViewModel.getApprovers(tangle).getHashes();
+            Set<Hash> approverHashes = ApproveeViewModel.load(tangle, txHash).getHashes();
             for (Hash approver : approverHashes) {
                 approvers.addAll(updateApproversRecursively(approver, txToApprovers, analyzedTips));
             }

--- a/src/test/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorImplTest.java
@@ -1,0 +1,63 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.Milestone;
+import com.iota.iri.hash.SpongeFactory;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.IntegerIndex;
+import com.iota.iri.service.tipselection.EntryPointSelector;
+import com.iota.iri.storage.Indexable;
+import com.iota.iri.storage.Persistable;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.utils.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EntryPointSelectorImplTest {
+
+    @Mock
+    private Milestone milestone;
+    @Mock
+    private Tangle tangle;
+
+    @Test
+    public void testEntryPointWithTangleData() throws Exception {
+        Hash milestoneHash = Hash.calculate(SpongeFactory.Mode.CURLP81, new int[]{1});
+        mockTangleBehavior(milestoneHash);
+        mockMilestoneTrackerBehavior(0, Hash.NULL_HASH);
+
+        EntryPointSelector entryPointSelector = new EntryPointSelectorImpl(tangle, milestone, false, 0);
+        Hash entryPoint = entryPointSelector.getEntryPoint(10);
+
+        Assert.assertEquals("The entry point should be the milestone in the Tangle", milestoneHash, entryPoint);
+    }
+
+    @Test
+    public void testEntryPointWithoutTangleData() throws Exception {
+        mockMilestoneTrackerBehavior(0, Hash.NULL_HASH);
+
+        EntryPointSelector entryPointSelector = new EntryPointSelectorImpl(tangle, milestone, false, 0);
+        Hash entryPoint = entryPointSelector.getEntryPoint(10);
+
+        Assert.assertEquals("The entry point should be the last tracked solid milestone", Hash.NULL_HASH, entryPoint);
+    }
+
+
+    private void mockMilestoneTrackerBehavior(int latestSolidSubtangleMilestoneIndex, Hash latestSolidSubtangleMilestone) {
+        milestone.latestSolidSubtangleMilestoneIndex = latestSolidSubtangleMilestoneIndex;
+        milestone.latestSolidSubtangleMilestone = latestSolidSubtangleMilestone;
+    }
+
+    private void mockTangleBehavior(Hash milestoneModelHash) throws Exception {
+        com.iota.iri.model.Milestone milestoneModel = new com.iota.iri.model.Milestone();
+        milestoneModel.index = new IntegerIndex(0);
+        milestoneModel.hash = milestoneModelHash;
+        Pair<Indexable, Persistable> indexMilestoneModel = new Pair<>(new IntegerIndex(0), milestoneModel);
+        Mockito.when(tangle.getFirst(com.iota.iri.model.Milestone.class, IntegerIndex.class))
+                .thenReturn(indexMilestoneModel);
+    }
+}

--- a/src/test/java/com/iota/iri/service/tipselection/impl/RatingOneTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/RatingOneTest.java
@@ -1,0 +1,75 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.HashId;
+import com.iota.iri.service.tipselection.RatingCalculator;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.iota.iri.controllers.TransactionViewModelTest.*;
+
+public class RatingOneTest {
+    private static final TemporaryFolder dbFolder = new TemporaryFolder();
+    private static final TemporaryFolder logFolder = new TemporaryFolder();
+    private static final String TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT =
+            "tx%d cumulative weight is not as expected";
+    private static Tangle tangle;
+    private static RatingCalculator rating;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        tangle.shutdown();
+        dbFolder.delete();
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        tangle = new Tangle();
+        dbFolder.create();
+        logFolder.create();
+        tangle.addPersistenceProvider(new RocksDBPersistenceProvider(dbFolder.getRoot().getAbsolutePath(), logFolder
+                .getRoot().getAbsolutePath(), 1000));
+        tangle.init();
+        rating = new RatingOne(tangle);
+    }
+
+    @Test
+    public void testCalculate() throws Exception {
+        TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
+        transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+                transaction1.getHash()), getRandomTransactionHash());
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+                transaction1.getHash()), getRandomTransactionHash());
+        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+                transaction3.getHash()), getRandomTransactionHash());
+        transaction.store(tangle);
+        transaction1.store(tangle);
+        transaction2.store(tangle);
+        transaction3.store(tangle);
+        transaction4.store(tangle);
+        UnIterableMap<HashId, Integer> rate = rating.calculate(transaction.getHash());
+
+        Assert.assertEquals(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT,
+                1, rate.get(transaction4.getHash()).intValue());
+        Assert.assertEquals(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT,
+                1, rate.get(transaction3.getHash()).intValue());
+        Assert.assertEquals(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT,
+                1, rate.get(transaction2.getHash()).intValue());
+        Assert.assertEquals(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT,
+                1, rate.get(transaction1.getHash()).intValue());
+        Assert.assertEquals(TX_CUMULATIVE_WEIGHT_IS_NOT_AS_EXPECTED_FORMAT,
+                1, rate.get(transaction.getHash()).intValue());
+    }
+}

--- a/src/test/java/com/iota/iri/service/tipselection/impl/RatingOneTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/RatingOneTest.java
@@ -23,7 +23,6 @@ public class RatingOneTest {
             "tx%d cumulative weight is not as expected";
     private static Tangle tangle;
     private static RatingCalculator rating;
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @AfterClass
     public static void tearDown() throws Exception {

--- a/src/test/java/com/iota/iri/service/tipselection/impl/TailFinderImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/TailFinderImplTest.java
@@ -1,0 +1,92 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.TransactionTestUtils;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.controllers.TransactionViewModelTest;
+import com.iota.iri.model.Hash;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Optional;
+
+public class TailFinderImplTest {
+
+    private static final TemporaryFolder dbFolder = new TemporaryFolder();
+    private static final TemporaryFolder logFolder = new TemporaryFolder();
+    private static Tangle tangle;
+    private TailFinderImpl tailFinder;
+
+    public TailFinderImplTest() {
+        tailFinder = new TailFinderImpl(tangle);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        tangle.shutdown();
+        dbFolder.delete();
+        logFolder.delete();
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        tangle = new Tangle();
+        dbFolder.create();
+        logFolder.create();
+        tangle.addPersistenceProvider(new RocksDBPersistenceProvider(dbFolder.getRoot().getAbsolutePath(), logFolder
+                .getRoot().getAbsolutePath(), 1000));
+        tangle.init();
+    }
+
+    @Test
+    public void findTailTest() throws Exception {
+        TransactionViewModel txa = new TransactionViewModel(TransactionViewModelTest.getRandomTransactionTrits(), TransactionViewModelTest.getRandomTransactionHash());
+        txa.store(tangle);
+
+        TransactionViewModel tx2 = TransactionTestUtils.createBundleHead(2);
+        tx2.store(tangle);
+
+        TransactionViewModel tx1 = TransactionTestUtils.createTransactionWithTrunkBundleHash(tx2, txa.getHash());
+        tx1.store(tangle);
+
+        TransactionViewModel tx0 = TransactionTestUtils.createTransactionWithTrunkBundleHash(tx1, txa.getHash());
+        tx0.store(tangle);
+
+        //negative index - make sure we stop at 0
+        TransactionViewModel txNeg = TransactionTestUtils.createTransactionWithTrunkBundleHash(tx0, txa.getHash());
+        txNeg.store(tangle);
+
+        TransactionViewModel txLateTail = TransactionTestUtils.createTransactionWithTrunkBundleHash(tx1, txa.getHash());
+        txLateTail.store(tangle);
+
+        Optional<Hash> tail = tailFinder.findTail(tx2.getHash());
+        Assert.assertTrue("no tail was found", tail.isPresent());
+        Assert.assertEquals("Expected tail not found", tx0.getHash(), tail.get());
+    }
+
+
+    @Test
+    public void findMissingTailTest() throws Exception {
+        TransactionViewModel txa = new TransactionViewModel(TransactionViewModelTest.getRandomTransactionTrits(),
+                TransactionViewModelTest.getRandomTransactionHash());
+        txa.store(tangle);
+
+        TransactionViewModel tx2 = TransactionTestUtils.createBundleHead(2);
+        tx2.store(tangle);
+
+        TransactionViewModel tx1 = TransactionTestUtils.createTransactionWithTrunkBundleHash(tx2, txa.getHash());
+        tx1.store(tangle);
+
+        TransactionViewModel tx0 = new TransactionViewModel(TransactionViewModelTest
+                .getRandomTransactionWithTrunkAndBranch(tx1.getHash(), tx2.getHash()),
+                TransactionViewModelTest.getRandomTransactionHash());
+        tx0.store(tangle);
+
+        Optional<Hash> tail = tailFinder.findTail(tx2.getHash());
+        Assert.assertFalse("tail was found, but should me missing", tail.isPresent());
+    }
+}

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -1,0 +1,88 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.LedgerValidator;
+import com.iota.iri.Milestone;
+import com.iota.iri.Snapshot;
+import com.iota.iri.TransactionValidator;
+import com.iota.iri.conf.Configuration;
+import com.iota.iri.controllers.TipsViewModel;
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.network.TransactionRequester;
+import com.iota.iri.service.tipselection.WalkValidator;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
+import com.iota.iri.zmq.MessageQ;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.iota.iri.controllers.TransactionViewModelTest.*;
+
+public class WalkValidatorImplTest {
+
+    private static final TemporaryFolder dbFolder = new TemporaryFolder();
+    private static final TemporaryFolder logFolder = new TemporaryFolder();
+    private static Tangle tangle;
+    private static WalkValidator walkValidator;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        tangle.shutdown();
+        dbFolder.delete();
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        tangle = new Tangle();
+        dbFolder.create();
+        logFolder.create();
+        tangle.addPersistenceProvider(new RocksDBPersistenceProvider(dbFolder.getRoot().getAbsolutePath(), logFolder
+                .getRoot().getAbsolutePath(), 1000));
+        tangle.init();
+        MessageQ messageQ = new MessageQ(0, null, 1, false);
+
+        TipsViewModel tipsViewModel = new TipsViewModel();
+        TransactionRequester transactionRequester = new TransactionRequester(tangle, messageQ);
+        TransactionValidator transactionValidator = new TransactionValidator(tangle, tipsViewModel, transactionRequester,
+                messageQ, Long.parseLong(Configuration.GLOBAL_SNAPSHOT_TIME));
+        int milestoneStartIndex = Integer.parseInt(Configuration.MAINNET_MILESTONE_START_INDEX);
+        int numOfKeysInMilestone = Integer.parseInt(Configuration.MAINNET_NUM_KEYS_IN_MILESTONE);
+        Milestone milestone = new Milestone(tangle, Hash.NULL_HASH, Snapshot.init(
+                Configuration.MAINNET_SNAPSHOT_FILE, Configuration.MAINNET_SNAPSHOT_SIG_FILE, false).clone(),
+                transactionValidator, false, messageQ, numOfKeysInMilestone,
+                milestoneStartIndex, true);
+        LedgerValidator ledgerValidator = new LedgerValidator(tangle, milestone, transactionRequester, messageQ);
+
+        walkValidator  = new WalkValidatorImpl(tangle, ledgerValidator, transactionValidator, milestone, 15);
+    }
+
+
+    @Test
+    public void shouldPassValidation() throws Exception {
+        //build a small tangle - 1,2,3,4 point to  transaction
+        TransactionViewModel transaction;
+        transaction = new TransactionViewModel(getRandomTransactionWithTrunkAndBranchValidBundle(Hash.NULL_HASH,
+                Hash.NULL_HASH), getRandomTransactionHash());
+        transaction.store(tangle);
+
+        Assert.assertTrue(walkValidator.isValid(transaction.getHash()));
+    }
+
+    @Test
+    public void shouldFailValidation() throws Exception {
+        //build a small tangle - 1,2,3,4 point to  transaction
+        TransactionViewModel transaction;
+        transaction = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(Hash.NULL_HASH,
+                Hash.NULL_HASH), getRandomTransactionHash());
+        transaction.store(tangle);
+
+        Assert.assertFalse(walkValidator.isValid(transaction.getHash()));
+    }
+
+}

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkValidatorImplTest.java
@@ -29,7 +29,6 @@ public class WalkValidatorImplTest {
     private static final TemporaryFolder logFolder = new TemporaryFolder();
     private static Tangle tangle;
     private static WalkValidator walkValidator;
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @AfterClass
     public static void tearDown() throws Exception {

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
@@ -1,0 +1,268 @@
+package com.iota.iri.service.tipselection.impl;
+
+import com.iota.iri.controllers.TransactionViewModel;
+import com.iota.iri.model.Hash;
+import com.iota.iri.model.HashId;
+import com.iota.iri.service.tipselection.RatingCalculator;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
+import com.iota.iri.utils.collections.interfaces.UnIterableMap;
+import com.iota.iri.zmq.MessageQ;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+
+import static com.iota.iri.controllers.TransactionViewModelTest.*;
+
+public class WalkerAlphaTest {
+    private static final TemporaryFolder dbFolder = new TemporaryFolder();
+    private static final TemporaryFolder logFolder = new TemporaryFolder();
+    private static Tangle tangle;
+    private static WalkerAlpha walker;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        tangle.shutdown();
+        dbFolder.delete();
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        tangle = new Tangle();
+        dbFolder.create();
+        logFolder.create();
+        tangle.addPersistenceProvider(new RocksDBPersistenceProvider(dbFolder.getRoot().getAbsolutePath(), logFolder
+                .getRoot().getAbsolutePath(), 1000));
+        tangle.init();
+        MessageQ messageQ = new MessageQ(0, null, 1, false);
+
+        walker = new WalkerAlpha(1, new Random(1), tangle, messageQ, (Optional::of));
+    }
+
+
+    @Test
+    public void testWalkEndsOnlyInRating() throws Exception {
+        //build a small tangle - 1,2,3,4 point to  transaction
+        TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
+        transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+
+        transaction.store(tangle);
+        transaction1.store(tangle);
+        transaction2.store(tangle);
+        transaction3.store(tangle);
+
+        //calculate rating
+        RatingCalculator ratingCalculator = new RatingOne(tangle);
+        UnIterableMap<HashId, Integer> rating = ratingCalculator.calculate(transaction.getHash());
+
+        //add 4 after the rating was calculated
+        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction4.store(tangle);
+
+        for (int i=0; i < 100; i++) {
+            //select
+            Hash tip = walker.walk(transaction.getHash(), rating, (o -> true));
+
+            Assert.assertTrue(tip != null);
+            //log.info("selected tip: " + tip.toString());
+            Assert.assertTrue(!transaction4.getHash().equals(tip));
+        }
+    }
+
+    @Test
+    public void showWalkDistributionAlphaHalf() throws Exception {
+
+        //build a small tangle - 1,2,3,4 point to  transaction
+        TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
+        transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+
+        transaction.store(tangle);
+        transaction1.store(tangle);
+        transaction2.store(tangle);
+        transaction3.store(tangle);
+
+        //calculate rating
+        RatingCalculator ratingCalculator = new RatingOne(tangle);
+        UnIterableMap<HashId, Integer> rating = ratingCalculator.calculate(transaction.getHash());
+        //set a higher rate for transaction2
+        rating.put(transaction2.getHash(), 10);
+
+        Map<Hash, Integer> counters = new HashMap<>(rating.size());
+        int iterations = 100;
+
+        walker.setAlpha(0.3);
+        for (int i=0; i < iterations; i++) {
+            //select
+            Hash tip = walker.walk(transaction.getHash(), rating, (o -> true));
+
+            Assert.assertNotNull(tip);
+            counters.put(tip, 1 + counters.getOrDefault(tip, 0));
+        }
+
+        for (Map.Entry<Hash, Integer> entry : counters.entrySet()) {
+            log.info(entry.getKey().toString() + " : " + entry.getValue());
+        }
+
+        Assert.assertTrue(counters.get(transaction2.getHash()) > iterations / 2);
+    }
+
+    @Test
+    public void showWalkDistributionAlphaZero() throws Exception {
+
+        //build a small tangle - 1,2,3,4 point to  transaction
+        TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
+        transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+
+        transaction.store(tangle);
+        transaction1.store(tangle);
+        transaction2.store(tangle);
+        transaction3.store(tangle);
+
+        //calculate rating
+        RatingCalculator ratingCalculator = new RatingOne(tangle);
+       UnIterableMap<HashId, Integer> rating = ratingCalculator.calculate(transaction.getHash());
+        //set a higher rate for transaction2
+        rating.put(transaction2.getHash(), 10);
+
+        //add 4 after the rating was calculated
+        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction4.store(tangle);
+
+        Map<Hash, Integer> counters = new HashMap<>(rating.size());
+        int iterations = 100;
+
+        walker.setAlpha(0);
+        for (int i=0; i < iterations; i++) {
+            //select
+            Hash tip = walker.walk(transaction.getHash(), rating, (o -> true));
+
+            Assert.assertNotNull(tip);
+            counters.put(tip, 1 + counters.getOrDefault(tip, 0));
+        }
+
+        for (Map.Entry<Hash, Integer> entry : counters.entrySet()) {
+            log.info(entry.getKey().toString() + " : " + entry.getValue());
+        }
+
+        Assert.assertTrue(counters.get(transaction1.getHash()) > iterations / 6);
+    }
+
+    @Test
+    public void testWalk() throws Exception {
+        //build a small tangle
+        TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
+        transaction = new TransactionViewModel(getRandomTransactionTrits(), Hash.NULL_HASH);
+        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+                transaction1.getHash()), getRandomTransactionHash());
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+                transaction1.getHash()), getRandomTransactionHash());
+        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction2.getHash(),
+                transaction3.getHash()), getRandomTransactionHash());
+        transaction.store(tangle);
+        transaction1.store(tangle);
+        transaction2.store(tangle);
+        transaction3.store(tangle);
+        transaction4.store(tangle);
+
+        //calculate rating
+        RatingCalculator ratingCalculator = new RatingOne(tangle);
+       UnIterableMap<HashId, Integer> rating = ratingCalculator.calculate(transaction.getHash());
+
+        //reach the tips
+        Hash tip = walker.walk(transaction.getHash(), rating, (o -> true));
+
+        log.info("selected tip: " + tip.toString());
+        Assert.assertEquals(tip, transaction4.getHash());
+    }
+
+    @Test
+    public void testWalkDiamond() throws Exception {
+        //build a small tangle
+        TransactionViewModel transaction, transaction1, transaction2, transaction3;
+        transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
+                transaction.getHash()), getRandomTransactionHash());
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction1.getHash(),
+                transaction2.getHash()), getRandomTransactionHash());
+        transaction.store(tangle);
+        transaction1.store(tangle);
+        transaction2.store(tangle);
+        transaction3.store(tangle);
+
+        //calculate rating
+        RatingCalculator ratingCalculator = new RatingOne(tangle);
+       UnIterableMap<HashId, Integer> rating = ratingCalculator.calculate(transaction.getHash());
+
+        //reach the tips
+        Hash tip = walker.walk(transaction.getHash(), rating, (o -> true));
+
+        log.info("selected tip: " + tip.toString());
+        Assert.assertEquals(tip, transaction3.getHash());
+    }
+
+    @Test
+    public void testWalkChain() throws Exception {
+        //build a small tangle
+        TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
+        transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
+        transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+                transaction.getHash(), transaction.getHash()), getRandomTransactionHash());
+        transaction2 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+                transaction1.getHash(), transaction1.getHash()), getRandomTransactionHash());
+        transaction3 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+                transaction2.getHash(), transaction2.getHash()), getRandomTransactionHash());
+        transaction4 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(
+                transaction3.getHash(), transaction3.getHash()), getRandomTransactionHash());
+        transaction.store(tangle);
+        transaction1.store(tangle);
+        transaction2.store(tangle);
+        transaction3.store(tangle);
+        transaction4.store(tangle);
+
+        //calculate rating
+        RatingCalculator ratingCalculator = new RatingOne(tangle);
+       UnIterableMap<HashId, Integer> rating = ratingCalculator.calculate(transaction.getHash());
+
+        //reach the tips
+        Hash tip = walker.walk(transaction.getHash(), rating, (o -> true));
+
+        log.info("selected tip: " + tip.toString());
+        Assert.assertEquals(tip, transaction4.getHash());
+    }
+
+}
+

--- a/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/WalkerAlphaTest.java
@@ -90,7 +90,7 @@ public class WalkerAlphaTest {
     public void showWalkDistributionAlphaHalf() throws Exception {
 
         //build a small tangle - 1,2,3,4 point to  transaction
-        TransactionViewModel transaction, transaction1, transaction2, transaction3, transaction4;
+        TransactionViewModel transaction, transaction1, transaction2, transaction3;
         transaction = new TransactionViewModel(getRandomTransactionTrits(), getRandomTransactionHash());
         transaction1 = new TransactionViewModel(getRandomTransactionWithTrunkAndBranch(transaction.getHash(),
                 transaction.getHash()), getRandomTransactionHash());


### PR DESCRIPTION
# Description
Rework of the Tip Selection algorithm, to better match the IOTA whitepaper

This is a complete rewrite of the tip selection algorithm in IRI,
Entry point selection, rating calculation, and walkers.

*This PR only introduces the code - the integration and clean up of `TipsManager` is a separate PR.

Main features:

1. Cumulative weights are used (as opposed to an estimated calculation).

1. `exp(alpha * Hy)` transition function from the IOTA whitepaper (as opposed to `Hy^(-3)` estimation)

1. Walkers don't stop at an invalid transaction but ignore them instead.

1. Code organization for better readability and maintainability

Fixes #774 #770 #771

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Unit tests
- Local testnets
- Running canaries on the mainnet
- Metrics collection using #767

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
